### PR TITLE
Update PostgreSqlPlatform.php

### DIFF
--- a/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
+++ b/lib/Doctrine/DBAL/Platforms/PostgreSqlPlatform.php
@@ -525,7 +525,7 @@ class PostgreSqlPlatform extends AbstractPlatform
                 continue;
             }
 
-            $oldColumnName = $columnDiff->getOldColumnName()->getQuotedName($this);
+            $oldColumnName = $columnDiff->fromColumn->getQuotedName($this);
             $column = $columnDiff->column;
 
             if ($columnDiff->hasChanged('type') || $columnDiff->hasChanged('precision') || $columnDiff->hasChanged('scale') || $columnDiff->hasChanged('fixed')) {


### PR DESCRIPTION
if use getOldColumnName will create a new instance of  Identifier and will lost the "$_quoted" info.  
so if the colume name contains upper letter will not be quoted.
